### PR TITLE
add .d.ts declarations to output

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -18,6 +18,7 @@
     "Wikipedia"
   ],
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "start": "node dist/index.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,10 @@
     "noUnusedLocals": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "declaration": true
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
Fixes #3 :)

The source maps are unnecessary, since they point to `/src` which isn't available in the dist package.

![image](https://user-images.githubusercontent.com/697707/86516282-ea2c5f80-be27-11ea-9bdc-44ce0f9ca770.png)

No src here:
![image](https://user-images.githubusercontent.com/697707/86516287-ef89aa00-be27-11ea-8eb4-bc8157ddf6a7.png)
